### PR TITLE
Support empty conditions

### DIFF
--- a/src/org/spootnik/riemann/thresholds.clj
+++ b/src/org/spootnik/riemann/thresholds.clj
@@ -30,7 +30,7 @@
              (cond
               (and exact (not= (double metric) (double exact))) "critical"
               (and exact (= (double metric) (double exact)))    "ok"
-              ((if invert <= >) metric critical) "critical"
-              ((if invert <= >) metric warning)  "warning"
+              (and critical ((if invert <= >) metric critical)) "critical"
+              (and warning ((if invert <= >) metric warning))  "warning"
               :else                              "ok"))
       event)))

--- a/test/org/spootnik/riemann/thresholds_test.clj
+++ b/test/org/spootnik/riemann/thresholds_test.clj
@@ -9,6 +9,7 @@
    "cpu-nice" {:warning 50 :critical 20}   
    "cpu-idle" {:warning 50 :critical 20 :invert true}
    "cpu-idle3" {:warning 50 :critical 20 :invert true}
+   "cpu-idle4" {}
    "cpu-steal" {:warning 50 :critical 20}})
 
 (deftest forward-threshold-test
@@ -22,6 +23,8 @@
              (testfn {:service "cpu-idle" :metric 0})))
       (is (= {:service "cpu-idle" :metric 40 :state "warning"}
              (testfn {:service "cpu-idle" :metric 40})))
+      (is (= {:service "cpu-idle4" :metric 20 :state "ok"}
+             (testfn {:service "cpu-idle4" :metric 20})))
       (is (= {:service "foo"}
              (testfn {:service "foo"})))
       (is (= {:service "foo" :metric 2}


### PR DESCRIPTION
This is a very small patch to support empty :critical and/or :warning options (in case you'd prefer to forego either or want no thresholds).
