### PR TITLE
project.clj: updated riemann dependency to 0.2.10, since some riemann…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :profiles {:dev {:dependencies [[riemann "0.2.10"]]}}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]]
   :omit-source false)

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/pyr/riemann-extra"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :profiles {:dev {:dependencies [[riemann "0.2.4"]]}}
+  :profiles {:dev {:dependencies [[riemann "0.2.10"]]}}
   :dependencies [[org.clojure/clojure "1.5.1"]]
   :omit-source false)


### PR DESCRIPTION
… 0.2.4 deps are now unreachable
