### PR TITLE
Reverse thresholds

### DIFF
--- a/src/org/spootnik/riemann/thresholds.clj
+++ b/src/org/spootnik/riemann/thresholds.clj
@@ -34,11 +34,10 @@
   (let [re-patterns (remove (comp string? key) thresholds)]
     (fn [{:keys [metric tags] :as event}]
       (try
-        (if metric
-          (let [{:keys [warning reverse-warning critical
-                        reverse-critical invert exact add-tags]}
-                (find-threshold thresholds re-patterns event)
-                op (if invert <= >)]
+        (if-let [{:keys [warning reverse-warning critical
+                         reverse-critical invert exact add-tags]}
+                 (if metric (find-threshold thresholds re-patterns event))]
+          (let [op (if invert <= >)]
             (assoc event
               :tags (union (set tags) (set add-tags))
               :state

--- a/src/org/spootnik/riemann/thresholds.clj
+++ b/src/org/spootnik/riemann/thresholds.clj
@@ -34,18 +34,23 @@
   (let [re-patterns (filter (complement (comp string? key)) thresholds)]
     (fn [{:keys [metric tags] :as event}]
       (try
-        (if-let [{:keys [warning critical invert exact add-tags]}
-                 (if metric (find-threshold thresholds re-patterns event))]
-          (assoc event
-            :tags (union (set tags) (set add-tags))
-            :state
-            (cond
-             (nil? metric)                       "unknown"
-             (and exact (not= (double metric) (double exact))) "critical"
-             (and exact (= (double metric) (double exact)))    "ok"
-             (and critical ((if invert <= >) metric critical)) "critical"
-             (and warning ((if invert <= >) metric warning))  "warning"
-             :else                              "ok"))
+        (if metric
+          (let [{:keys [warning reverse-warning critical
+                        reverse-critical invert exact add-tags]}
+                (find-threshold thresholds re-patterns event)
+                op (if invert <= >)]
+            (assoc event
+              :tags (union (set tags) (set add-tags))
+              :state
+              (cond
+                (nil? metric) "unknown"
+                (and exact (not= (double metric) (double exact))) "critical"
+                (and exact (= (double metric) (double exact))) "ok"
+                (or (and critical (op metric critical))
+                    (and reverse-critical (op reverse-critical metric))) "critical"
+                (or (and warning (op metric warning))
+                    (and reverse-warning (op reverse-warning metric))) "warning"
+                :else "ok")))
           event)
         (catch Exception e
           (error e "threshold-check failed for " event))))))

--- a/src/org/spootnik/riemann/thresholds.clj
+++ b/src/org/spootnik/riemann/thresholds.clj
@@ -31,7 +31,7 @@
 
    The output function does not process events with no metrics"
   [thresholds]
-  (let [re-patterns (filter (complement (comp string? key)) thresholds)]
+  (let [re-patterns (remove (comp string? key) thresholds)]
     (fn [{:keys [metric tags] :as event}]
       (try
         (if metric


### PR DESCRIPTION
Hi there !

I think we should be able to test things like this in one operation :

```
small-critical-threshold < metric < big-critical-threshold 
```

(and ditto for warning).

So here's a patch implementing that feature. Not sure about the new fields name, though.

We have use for such things here and it simplifies greatly the implementation if we do it in riemann-extra instead of hacking it in riemann configuration.

What do you think ?
